### PR TITLE
Allow individual control of opacity and gradient

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,8 +34,9 @@ function setUpElevationGradient(viewer) {
 
     var imageryLayer = scene.imageryLayers.addImageryProvider(new ElevationGradient({
         terrainProvider: terrainProvider,
-        minElevation: 0,
-        maxElevation: 500,
+        gradientMinElevation: 500,
+        gradientMaxElevation: 1000,
+        opacityMinElevation: 650,
         majorContour: 25,
         minorContour: 5
     }));

--- a/lib/ElevationGradientImageryProvider.js
+++ b/lib/ElevationGradientImageryProvider.js
@@ -24,8 +24,8 @@ var TileRenderer = require('./TileRenderer');
  * @param {Object} options Object with the following properties:
  * @param {Object} options.terrainProvider The terrain provider to sample elevations from.
  * @param {Number} [options.minimumTileLevel] Control the usage of blank tiles for coarse levels.
- * @param {Number} [options.minElevation] The starting point for the elevation gradient.
- * @param {Number} [options.maxElevation] The finishing point for the elevation gradient.
+ * @param {Number} [options.gradientMinElevation] The starting point for the elevation gradient.
+ * @param {Number} [options.gradientMaxElevation] The finishing point for the elevation gradient.
  * @param {Number} [options.majorContour] The elevation spacing of major contour lines.
  * @param {Number} [options.minorContour] The elevation spacing of minor contour lines.
  * @param {Credit|String} [options.credit] The credit, which will is displayed on the canvas.
@@ -55,8 +55,9 @@ var ElevationGradientImageryProvider = function ElevationGradientImageryProvider
 
     this._minimumTileLevel = defaultValue(options.minimumTileLevel, 13);
 
-    this._minElevation = defaultValue(options.minElevation, 0);
-    this._maxElevation = defaultValue(options.maxElevation, 100);
+    this._gradientMinElevation = defaultValue(options.gradientMinElevation, 0);
+    this._gradientMaxElevation = defaultValue(options.gradientMaxElevation, 100);
+    this._opacityMinElevation = defaultValue(options.opacityMinElevation, 0);
 
     this._majorContour = defaultValue(options.majorContour, 10);
     this._minorContour = defaultValue(options.minorContour, 1);
@@ -255,8 +256,9 @@ ElevationGradientImageryProvider.prototype.requestImage = function(x, y, level) 
                 heights,
                 tileGeo._width,
                 tileDimension,
-                that._minElevation,
-                that._maxElevation,
+                that._gradientMinElevation,
+                that._gradientMaxElevation,
+                that._opacityMinElevation,
                 that._majorContour,
                 that._minorContour,
                 that._gradOpacity
@@ -278,8 +280,9 @@ ElevationGradientImageryProvider.prototype.requestImage = function(x, y, level) 
                     heights,
                     gridWidth,
                     tileDimension,
-                    that._minElevation,
-                    that._maxElevation,
+                    that._gradientMinElevation,
+                    that._gradientMaxElevation,
+                    that._opacityMinElevation,
                     that._majorContour,
                     that._minorContour,
                     that._gradOpacity

--- a/lib/TileRenderer.js
+++ b/lib/TileRenderer.js
@@ -78,7 +78,7 @@ function createProgram(gl, vertShaderSource, fragShaderSource) {
     return program;
 }
 
-TileRenderer.prototype.render = function(heights, gridDim, tileDimension, terrainMinElevation, terrainMaxElevation, majorContour, minorContour, gradOpacity) {
+TileRenderer.prototype.render = function(heights, gridDim, tileDimension, gradientMinElevation, gradientMaxElevation, opacityMinElevation, majorContour, minorContour, gradOpacity) {
     var gl = this._gl;
     var canvas = this._canvas;
     var program = this._program;
@@ -156,12 +156,15 @@ TileRenderer.prototype.render = function(heights, gridDim, tileDimension, terrai
             case 2:
                 gl.uniform2f(location, arguments[1], arguments[2]);
                 break;
+            case 3:
+                gl.uniform3f(location, arguments[1], arguments[2], arguments[3]);
+                break;
         }
     };
 
     setUniformF("u_resolution", canvas.width, canvas.height);
     setUniformF("u_tileElevationRange", minElevation, maxElevation);
-    setUniformF("u_terrainElevationRange", terrainMinElevation, terrainMaxElevation);
+    setUniformF("u_elevationRange", gradientMinElevation, gradientMaxElevation, opacityMinElevation);
     setUniformF("u_textureSize", canvas.width, canvas.height);
     setUniformF("u_tileDimension", tileDimension.x, tileDimension.y);
     setUniformF("u_zFactor", Z_FACTOR);

--- a/lib/shaders/elevationGradientFrag.glsl
+++ b/lib/shaders/elevationGradientFrag.glsl
@@ -14,7 +14,7 @@ uniform float u_gradOpacity;
 varying vec2 v_texCoord;
 
 uniform vec2 u_tileElevationRange;
-uniform vec2 u_terrainElevationRange;
+uniform vec3 u_elevationRange;
 
 #define M_PI 3.1415926535897932384626433832795
 #define CONTOUR_MAJOR_OPACITY 1.0
@@ -126,13 +126,13 @@ void main() {
 
     float hillshade = calcHillshade(a, b, c, d, e, f, g, h, i);
 
-    float ne = (e - u_terrainElevationRange.x) / (u_terrainElevationRange.y - u_terrainElevationRange.x);
+    float ne = (e - u_elevationRange.x) / (u_elevationRange.y - u_elevationRange.x);
     vec3 colourGrad = applyGrad(ne);
     vec3 colourHillshade = applyTint(hillshade);
 
     float contour = calcContour(u_minorContour, u_majorContour, a, b, c, d, e, f, g, h, i);
 
-    float alpha = ne > 0.01 ? u_gradOpacity: 0.0;
+    float alpha = (e > u_elevationRange.z) ? u_gradOpacity : 0.0;
     vec4 litColour = vec4(applyGamma(colourGrad * colourHillshade) * alpha, alpha);
 
     gl_FragColor = mix(litColour, vec4(1.,1.,1.,1.), contour);


### PR DESCRIPTION
Previously there was minElevation and maxElevation which controlled both opacity (transparent below minElevation) and colour gradient.  This splits the controls into gradientMinElevation, gradientMaxElevation and opacityMinElevation.